### PR TITLE
fix(rustdoc): wrap bare URL in angle brackets

### DIFF
--- a/pathing/meta/src/map.rs
+++ b/pathing/meta/src/map.rs
@@ -7,7 +7,7 @@ use {
 
 pub type MapID = u32;
 
-/// https://wiki.guildwars2.com/wiki/API:1/maps
+/// <https://wiki.guildwars2.com/wiki/API:1/maps>
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Map {


### PR DESCRIPTION
Wraps the bare URL in the `Map` struct doc comment in `pathing/meta/src/map.rs` with angle brackets so rustdoc renders it as a proper hyperlink.

Closes part of #64.