### PR TITLE
docs: add crate-level doc summaries to all workspace crates

### DIFF
--- a/api/client/src/lib.rs
+++ b/api/client/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
+//! GW2 API client and typed endpoint bindings.
 pub use gw2lib_model::{self as model, BulkEndpoint, Endpoint, EndpointWithId, FixedEndpoint, Language};
 use {
     core::{fmt, marker::PhantomData, mem, ops},

--- a/pathing/meta/src/lib.rs
+++ b/pathing/meta/src/lib.rs
@@ -1,3 +1,4 @@
+//! GW2 map metadata, coordinate spaces, and UI state types.
 pub mod coords;
 pub mod map;
 pub mod ui;

--- a/pathing/meta/src/lib.rs
+++ b/pathing/meta/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
 //! GW2 map metadata, coordinate spaces, and UI state types.
 pub mod coords;
 pub mod map;

--- a/pathing/pack/src/lib.rs
+++ b/pathing/pack/src/lib.rs
@@ -1,3 +1,4 @@
+//! Parser and data types for GW2 TacO pathing packs.
 pub mod attributes;
 pub mod category;
 pub mod loader;

--- a/pathing/pack/src/lib.rs
+++ b/pathing/pack/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
 //! Parser and data types for GW2 TacO pathing packs.
 pub mod attributes;
 pub mod category;

--- a/rt/ffi/src/lib.rs
+++ b/rt/ffi/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
 //! most of this hopefully is just a temporary staging ground for things
 //! before they're ready to be pulled into [arcffi]...
 

--- a/rt/hoard/src/lib.rs
+++ b/rt/hoard/src/lib.rs
@@ -1,3 +1,4 @@
+//! Shared collection utilities, string helpers, and statistics for TaimiHUD.
 use std::{borrow::Cow, hash};
 
 pub mod cmp;

--- a/rt/hoard/src/lib.rs
+++ b/rt/hoard/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
 //! Shared collection utilities, string helpers, and statistics for TaimiHUD.
 use std::{borrow::Cow, hash};
 

--- a/rt/input/src/lib.rs
+++ b/rt/input/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
 //! Input handling and keybind processing for TaimiHUD.
 #[cfg(feature = "windows")]
 pub mod win;

--- a/rt/input/src/lib.rs
+++ b/rt/input/src/lib.rs
@@ -1,3 +1,4 @@
+//! Input handling and keybind processing for TaimiHUD.
 #[cfg(feature = "windows")]
 pub mod win;
 

--- a/rt/sync/src/lib.rs
+++ b/rt/sync/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
 //! Synchronization primitives and async utilities for TaimiHUD.
 pub use std::sync::PoisonError as StdPoisonError;
 

--- a/rt/sync/src/lib.rs
+++ b/rt/sync/src/lib.rs
@@ -1,3 +1,4 @@
+//! Synchronization primitives and async utilities for TaimiHUD.
 pub use std::sync::PoisonError as StdPoisonError;
 
 pub mod arcs;

--- a/space/d3d/src/lib.rs
+++ b/space/d3d/src/lib.rs
@@ -1,3 +1,4 @@
+//! DirectX 11 abstractions and rendering primitives for TaimiHUD.
 pub mod blob;
 pub mod buffer;
 pub mod device;

--- a/space/d3d/src/lib.rs
+++ b/space/d3d/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
 //! DirectX 11 abstractions and rendering primitives for TaimiHUD.
 pub mod blob;
 pub mod buffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://taimihud.com/logotype-holo.png")]
 //! TaimiHUD addon — pathing, encounter timers, and squad markers.
 mod controller;
 mod exports;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+//! TaimiHUD addon — pathing, encounter timers, and squad markers.
 mod controller;
 mod exports;
 mod render;


### PR DESCRIPTION
Adds a \`#![doc(html_logo_url)]\` attribute and a one-line \`//!\` inner doc comment to the root \`lib.rs\` of every workspace crate:

- \`taimi_hud\` — pathing, encounter timers, and squad markers
- \`taimi_meta\` — GW2 map metadata, coordinate spaces, and UI state types
- \`taimi_pack\` — parser and data types for GW2 TacO pathing packs
- \`taimi_hoard\` — shared collection utilities, string helpers, and statistics
- \`taimi_input\` — input handling and keybind processing
- \`taimi_sync\` — synchronization primitives and async utilities
- \`taimi_d3d\` — DirectX 11 abstractions and rendering primitives
- \`taimi_api_client\` — GW2 API client and typed endpoint bindings
- \`taimi_ffi\` — already had a \`//!\` doc; adds the missing \`html_logo_url\` attr

Part of #64.