### PR TITLE
refactor: consolidate strum_macros into strum derive feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,8 +249,7 @@ serde_json = "1"
 #serde_jsonrc = { version = "0.1.0", features = [ "preserve_order"] }
 #serde_with = "3"
 json-strip-comments = "1"
-strum = "0.27.1"
-strum_macros = "0.27.1"
+strum = { version = "0.27.1", features = ["derive"] }
 reqwest = { version = "0.12.15", default-features = false, features = [ "stream", "rustls-tls-native-roots", "json" ] }
 tempfile = "3.19.1"
 bytes = "1.10.1"

--- a/src/controller/markers.rs
+++ b/src/controller/markers.rs
@@ -27,7 +27,7 @@ use {
         path::PathBuf,
         sync::Arc,
     },
-    strum_macros::{Display, FromRepr},
+    strum::{Display, FromRepr},
     taimi_meta::{
         coords::{FakeSpace, LocalSpace, ScreenPoint, ScreenSpace},
         ui::{MapCalibration, MapOpen, UiMap, UiState},

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -30,7 +30,7 @@ use {
     glam::f32::Vec3,
     relative_path::RelativePathBuf,
     std::{ffi::OsStr, future::Future, mem, path::PathBuf, sync::Arc, time::SystemTime},
-    strum_macros::Display,
+    strum::Display,
     taimi_meta::ui::gameplay::GameplayState,
     taimi_sync::watched,
     tokio::{

--- a/src/controller/pathing/mod.rs
+++ b/src/controller/pathing/mod.rs
@@ -25,7 +25,7 @@ use {
     anyhow::{anyhow, Context},
     futures::{FutureExt, StreamExt},
     std::{path::PathBuf, sync::Arc},
-    strum_macros::Display,
+    strum::Display,
     taimi_meta::ui::MapContext,
     taimi_pack::{attributes::Festivals, category::CategoryId, Pack},
     tokio::{

--- a/src/controller/timers.rs
+++ b/src/controller/timers.rs
@@ -12,7 +12,7 @@ use {
     anyhow::Context,
     futures::stream::StreamExt,
     std::{collections::HashMap, sync::Arc},
-    strum_macros::Display,
+    strum::Display,
     taimi_meta::ui::UiState,
     tokio::{
         fs::{create_dir_all, metadata},

--- a/src/marker/format.rs
+++ b/src/marker/format.rs
@@ -21,7 +21,7 @@ use {
         path::{Path, PathBuf},
         sync::Arc,
     },
-    strum_macros::{Display, EnumIter, FromRepr},
+    strum::{Display, EnumIter, FromRepr},
     taimi_meta::coords::LocalSpace,
     tokio::{
         fs::{create_dir_all, read_to_string, File, OpenOptions},

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -47,7 +47,7 @@ use {
             MutexGuard,
         },
     },
-    strum_macros::{Display, EnumIter},
+    strum::{Display, EnumIter},
     tokio::sync::mpsc::{Receiver, Sender},
 };
 

--- a/src/settings/settings_struct.rs
+++ b/src/settings/settings_struct.rs
@@ -30,7 +30,7 @@ use {
         },
         task::Poll,
     },
-    strum_macros::EnumIter,
+    strum::EnumIter,
     tokio::{
         fs::{create_dir_all, read_dir, read_to_string, try_exists, File},
         io::AsyncWriteExt,

--- a/src/settings/source/sources.rs
+++ b/src/settings/source/sources.rs
@@ -13,7 +13,7 @@ use {
         path::{Path, PathBuf},
         sync::LazyLock,
     },
-    strum_macros::Display,
+    strum::Display,
     tokio::{
         fs::{create_dir_all, read_to_string, File},
         io::AsyncWriteExt,

--- a/src/timer/alert.rs
+++ b/src/timer/alert.rs
@@ -3,7 +3,7 @@ use {
     relative_path::RelativePathBuf,
     serde::{Deserialize, Serialize},
     std::ops::Deref,
-    strum_macros::Display,
+    strum::Display,
     tokio::time::{Duration, Instant},
 };
 


### PR DESCRIPTION
`strum_macros` is redundant when `strum` is used with `features = ["derive"]` — the macros are re-exported from `strum` directly. This removes the separate `strum_macros` dependency and updates all import paths accordingly.

Part of #47.