### PR TITLE
refactor: replace manual is_empty Option patterns with str_opt_ref

### DIFF
--- a/src/render/config_tab.rs
+++ b/src/render/config_tab.rs
@@ -549,10 +549,7 @@ impl ConfigUpdateState {
             };
             if let Some(token) = gh_api_token {
                 BootstrapState::write_with(|state| {
-                    state.gh_api_token = match token.is_empty() {
-                        false => Some(token),
-                        true => None,
-                    };
+                    state.gh_api_token = taimi_hoard::str_opt(token);
                 });
             }
             ui.separator();

--- a/src/settings/state/bootstrap.rs
+++ b/src/settings/state/bootstrap.rs
@@ -353,11 +353,7 @@ impl BootstrapState {
     }
 
     pub fn gh_api_token(&self) -> Option<&str> {
-        match &self.gh_api_token {
-            None => None,
-            Some(token) if token.is_empty() => None,
-            Some(token) => Some(token),
-        }
+        self.gh_api_token.as_deref().and_then(taimi_hoard::str_opt_ref)
     }
     pub fn anet_api_token<'a>(&'a self, acc: &str) -> Option<&'a SavedApiToken> {
         SavedApiToken::token_by_account_name(&self.anet_api_token, acc)

--- a/src/settings/state/ui/mod.rs
+++ b/src/settings/state/ui/mod.rs
@@ -69,10 +69,7 @@ pub struct PathingSearchState {
 }
 impl PathingSearchState {
     pub fn query(&self) -> Option<&str> {
-        match &self.query[..] {
-            s if s.is_empty() => None,
-            s => Some(s),
-        }
+        taimi_hoard::str_opt_ref(&self.query)
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/space/pack/pack.rs
+++ b/src/space/pack/pack.rs
@@ -486,10 +486,11 @@ impl ActivePack {
     }
 
     pub(crate) fn draw_tooltip_category(ui: &Ui, category: &Category) {
-        let desc = match &category.marker_attributes.tip_description {
-            Some(desc) if !desc.is_empty() => Some(&desc[..]),
-            _ => None,
-        };
+        let desc = category
+            .marker_attributes
+            .tip_description
+            .as_deref()
+            .and_then(taimi_hoard::str_opt_ref);
         let title = match &category.marker_attributes.tip_name {
             Some(title) if !title.is_empty() && !category.display_name().starts_with(&title[..]) =>
                 Some(&title[..]),
@@ -507,10 +508,10 @@ impl ActivePack {
     }
 
     fn draw_tooltip_poi(ui: &Ui, attributes: &MarkerAttributes) {
-        let desc = match &attributes.tip_description {
-            Some(desc) if !desc.is_empty() => Some(&desc[..]),
-            _ => None,
-        };
+        let desc = attributes
+            .tip_description
+            .as_deref()
+            .and_then(taimi_hoard::str_opt_ref);
 
         if let Some(title) = &attributes.tip_name {
             let _title_font = desc.map(|_| RenderState::push_font("big", ui));


### PR DESCRIPTION
Uses str_opt_ref/str_opt from taimi_hoard in the five remaining spots
that were still doing manual is_empty match blocks.

Part of #64.