### PR TITLE
fix(rustdoc): fix broken doc links and bare URL in subcrates

### DIFF
--- a/pathing/meta/src/coords/mod.rs
+++ b/pathing/meta/src/coords/mod.rs
@@ -526,7 +526,7 @@ where
     Transform3::from_matrix_unchecked(trans.matrix)
 }
 
-/// XXX: [glam::Matrix4::look_to_lh] does not normalize the up cross vector,
+/// XXX: [glam::Mat4::look_to_lh] does not normalize the up cross vector,
 /// but we do?
 ///
 /// the difference is probably just a rounding error or we're wrong idk

--- a/pathing/meta/src/map.rs
+++ b/pathing/meta/src/map.rs
@@ -7,7 +7,7 @@ use {
 
 pub type MapID = u32;
 
-/// https://wiki.guildwars2.com/wiki/API:1/maps
+/// <https://wiki.guildwars2.com/wiki/API:1/maps>
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Map {

--- a/space/d3d/src/dx11/depth.rs
+++ b/space/d3d/src/dx11/depth.rs
@@ -62,7 +62,7 @@ impl DepthState {
         StencilFailOp: StencilOp::KEEP,
         StencilPassOp: StencilOp::KEEP,
     };
-    /// depth=[D3D11_COMPARISON_LESS](ComparisonFunc::Less), stencil=[off](Self::STENCILOP_DEFAULT)
+    /// depth=[D3D11_COMPARISON_LESS](ComparisonFunc::LESS), stencil=[off](Self::STENCILOP_DEFAULT)
     pub const DESC_DEFAULT: D3D11_DEPTH_STENCIL_DESC = D3D11_DEPTH_STENCIL_DESC {
         DepthEnable: BOOL(1),
         DepthWriteMask: d3d11::D3D11_DEPTH_WRITE_MASK_ALL,


### PR DESCRIPTION
Fixes three doc warnings found while going over rustdoc output.

- bare URL in map.rs wrapped in angle brackets
- glam link corrected from Matrix4 to Mat4 (wrong type, glam uses Mat4)
- ComparisonFunc::Less corrected to LESS to match the actual constant

Part of #64.