### PR TITLE
chore(pack): remove redundant clone calls on Copy types

### DIFF
--- a/pathing/pack/src/attributes/mod.rs
+++ b/pathing/pack/src/attributes/mod.rs
@@ -503,16 +503,16 @@ pub struct FilterAttributes {
 impl FilterAttributes {
     pub fn merge(&mut self, base: &Self) {
         if self.festivals.is_none() {
-            self.festivals = base.festivals.clone();
+            self.festivals = base.festivals;
         }
         if self.mounts.is_none() {
-            self.mounts = base.mounts.clone();
+            self.mounts = base.mounts;
         }
         if self.professions.is_none() {
-            self.professions = base.professions.clone();
+            self.professions = base.professions;
         }
         if self.races.is_none() {
-            self.races = base.races.clone();
+            self.races = base.races;
         }
         if self.specializations.is_none() {
             self.specializations = base.specializations.clone();

--- a/pathing/pack/src/pack.rs
+++ b/pathing/pack/src/pack.rs
@@ -430,7 +430,7 @@ impl<'a> PackBuilder<'a> {
                     cat
                 },
                 None if id.as_str().is_empty() => {
-                    if warnings_empty.insert(guid.clone()) {
+                    if warnings_empty.insert(*guid) {
                         #[cfg(todo)]
                         let guid = Guid::from_ref(guid);
                         log::warn!("No category provided for {guid}");


### PR DESCRIPTION
These fields are Copy already, so cloning before assigning was just wasted work. Same deal for a guid we were cloning just to check if we'd already logged a warning for it.