### PR TITLE
fix(sync): return bool from try_mark_changed instead of Result<(), ()>

### DIFF
--- a/rt/sync/src/watched/mod.rs
+++ b/rt/sync/src/watched/mod.rs
@@ -167,12 +167,12 @@ impl<T> Watcher<T> {
             r.mark_unchanged();
         }
     }
-    pub fn try_mark_changed(&mut self) -> Result<(), ()> {
+    pub fn try_mark_changed(&mut self) -> bool {
         if let Some(r) = self.get_receiver_mut() {
             r.mark_changed();
-            Ok(())
+            true
         } else {
-            Err(())
+            false
         }
     }
     pub fn try_read(&self) -> Option<watch::Ref<'_, T>> {


### PR DESCRIPTION
Result<(), ()> doesn't carry any actual error info, it's just a bool wearing a costume. Both call sites already throw the result away, so this doesn't change any behavior, just makes the signature honest.