### PR TITLE
fix(meta): remove dead condition from encoder flush loop

### DIFF
--- a/pathing/meta/build.rs
+++ b/pathing/meta/build.rs
@@ -118,10 +118,8 @@ where
         let consumed = buf.written().len();
         src.consume(consumed);
         src_len += consumed;
-        if out.written().len() > out.unwritten().len() || true {
-            dest.write_all(out.written())?;
-            out.reset();
-        }
+        dest.write_all(out.written())?;
+        out.reset();
     }
     while !encoder.finish(&mut out)? {
         assert!(!out.written().is_empty());


### PR DESCRIPTION
The flush condition had an `|| true` tacked on, so it always ran regardless of the actual check. Removed the dead half.