### PR TITLE
fix: implement From instead of suppressing clippy::from_over_into

### DIFF
--- a/pathing/pack/src/attributes/festival.rs
+++ b/pathing/pack/src/attributes/festival.rs
@@ -67,9 +67,9 @@ impl AsRef<str> for Festival {
         self.as_str()
     }
 }
-impl Into<String> for Festival {
-    fn into(self) -> String {
-        self.as_str().into()
+impl From<Festival> for String {
+    fn from(value: Festival) -> String {
+        value.as_str().into()
     }
 }
 

--- a/space/d3d/src/shader/mod.rs
+++ b/space/d3d/src/shader/mod.rs
@@ -313,9 +313,9 @@ mod defs {
         }
     }
 
-    impl Into<BTreeMap<String, String>> for ShaderDefinitions {
-        fn into(self) -> BTreeMap<String, String> {
-            self.defs.into_iter().map(Into::into).collect()
+    impl From<ShaderDefinitions> for BTreeMap<String, String> {
+        fn from(value: ShaderDefinitions) -> BTreeMap<String, String> {
+            value.defs.into_iter().map(Into::into).collect()
         }
     }
 


### PR DESCRIPTION
Turns out the orphan rule claim in the original code was wrong -- Festival and ShaderDefinitions are local types, so implementing From<Festival> for String and From<ShaderDefinitions> for BTreeMap<String, String> directly is totally legal (verified by actually compiling both). Went with clippy's actual suggestion instead of suppressing it. Into still works everywhere via std's blanket impl, so nothing downstream changes.