### PR TITLE
fix(hoard): rename StrFmt::from_str to from_cached

### DIFF
--- a/rt/hoard/src/lazyfmt.rs
+++ b/rt/hoard/src/lazyfmt.rs
@@ -323,7 +323,7 @@ impl<F> StrFmt<F> {
     pub const fn new(f: F) -> Self {
         Self { f, displayed: OnceCell::new() }
     }
-    pub fn from_str<S: Into<Box<str>>>(s: S) -> Self
+    pub fn from_cached<S: Into<Box<str>>>(s: S) -> Self
     where
         F: Default,
     {


### PR DESCRIPTION
StrFmt::from_str doesn't implement the FromStr trait, it just happens to share the name, which reads as if it does. Renamed to from_cached to actually describe what it's doing.