### PR TITLE
fix(ffi): remove to_string shadow on Str0

### DIFF
--- a/rt/ffi/src/cstr.rs
+++ b/rt/ffi/src/cstr.rs
@@ -89,10 +89,6 @@ impl Str0 {
     }
 
     #[inline(always)]
-    pub fn to_string(&self) -> String {
-        self.as_str().into()
-    }
-    #[inline(always)]
     pub fn to_string0(&self) -> String0 {
         unsafe { String0::from_c_string_unchecked(self.to_c_string()) }
     }


### PR DESCRIPTION
Str0 already gets to_string from its Display impl. The inherent to_string method did the exact same thing but silently took priority over the trait one, which is just confusing to have around. Removed it.